### PR TITLE
zedcam: added calibration accessors

### DIFF
--- a/include/zedCamera.h
+++ b/include/zedCamera.h
@@ -36,6 +36,14 @@ class zedCamera
     // get camera info
     int getCameraInfo(CameraInfo& info);
 
+    // get and set camera intrinsics
+    cv::Mat getIntrinsicMatrix();
+    void setIntrinsicMatrix(const cv::Mat&);
+
+    // get and set camera distortion coeffs
+    cv::Mat getDistortionCoeffs();
+    void setDistortionCoeffs(const cv::Mat&);
+
     // save/load camera parameters (yml format)
     bool saveParams(const std::string fileName);
     bool loadParams(const std::string fileName);
@@ -56,6 +64,8 @@ class zedCamera
   private:
     sl::Camera m_camera;
     sl::CameraInformation m_cameraInformation;
+    cv::Mat m_intrinsic_matrix;
+    cv::Mat m_distortion_coeffs;
 
     cv::Mat slMat2cvMat(sl::Mat& input);
     int getOCVtype(sl::MAT_TYPE type);

--- a/src/testmain.cpp
+++ b/src/testmain.cpp
@@ -4,11 +4,13 @@
 int main(int argc, char** argv)
 {
     std::cout << "zedCamera test" << std::endl;
+    //
     zv::zedCamera zed;
     zv::ResolutionFPS resFPS = zv::ResolutionFPS::HD1080_30;
     std::cout << "opening camera" << std::endl;
     int ret = zed.open(resFPS);
     std::cout << "opening camera return: " << ret << std::endl;
+    //
     std::cout << "getting camera info" << std::endl;
     zv::CameraInfo info;
     ret = zed.getCameraInfo(info);
@@ -17,6 +19,13 @@ int main(int argc, char** argv)
               << "make=" << info.make << ", model=" << info.model << ", firmware=" << info.firmware
               << std::endl;
     std::cout << "camera connected: " << zed.isConnected() << std::endl;
+    //
+    std::cout << "getting camera instrinsics" << std::endl;
+    cv::Mat im = zed.getIntrinsicMatrix();
+    cv::Mat dm = zed.getDistortionCoeffs();
+    std::cout << "iMat = " << std::endl << " "  << im << std::endl << std::endl;
+    std::cout << "dMat = " << std::endl << " "  << dm << std::endl << std::endl;
+    //
     std::cout << "getting frame (cvMat)" << std::endl;
     cv::Mat capImage;
     ret = zed.getFrame(capImage);


### PR DESCRIPTION
zedcam: added calibration information accessors set/getIntrinsicMatrix and set/getDistortionCoeffs, that accept/return OpenCV matrices.